### PR TITLE
optimize layout, implement db pagination (500 limit), server-side column search, and document status visibility controls

### DIFF
--- a/business_needed_solutions/business_needed_solutions/page/bns_dashboard/bns_dashboard.js
+++ b/business_needed_solutions/business_needed_solutions/page/bns_dashboard/bns_dashboard.js
@@ -236,6 +236,39 @@ class BNSDashboard {
 					</div>
 				</div>
 
+				<!-- ======= PROOF OF DELIVERY (POD) HEALTH ======= -->
+				<div class="bns-section">
+					<div class="bns-section-title">
+						<i class="fa fa-truck"></i> ${__("Proof of Delivery (POD) Health")}
+					</div>
+					<div class="row" id="pod-health-cards">
+						<div class="col-lg-3 col-md-6 col-6 mb-3">
+							<div class="metric-card" id="pod-total-pending">
+								<div class="metric-value">--</div>
+								<div class="metric-label">${__("Total Pending (1+ Missing)")}</div>
+							</div>
+						</div>
+						<div class="col-lg-3 col-md-6 col-6 mb-3">
+							<div class="metric-card" id="pod-total-done">
+								<div class="metric-value">--</div>
+								<div class="metric-label">${__("Total Done POD")}</div>
+							</div>
+						</div>
+						<div class="col-lg-3 col-md-6 col-6 mb-3">
+							<div class="metric-card" id="pod-total-pending-all-missing">
+								<div class="metric-value">--</div>
+								<div class="metric-label">${__("Total Pending POD (3 Missing)")}</div>
+							</div>
+						</div>
+						<div class="col-lg-3 col-md-6 col-6 mb-3">
+							<div class="metric-card" id="pod-total-partial">
+								<div class="metric-value">--</div>
+								<div class="metric-label">${__("Total Partial POD")}</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
 				<!-- ======= QUICK LINKS ======= -->
 				<div class="bns-section">
 					<div class="bns-section-title">
@@ -1367,6 +1400,10 @@ class BNSDashboard {
 	bind_events() {
 		const self = this;
 
+		this.wrapper.find("#pod-health-cards .metric-card").css("cursor", "pointer").on("click", function () {
+			frappe.set_route("pod-dashboard");
+		});
+
 		this.wrapper.find(".section-header").on("click", function () {
 			const section = $(this).data("section");
 			self.toggle_section(section);
@@ -1721,6 +1758,15 @@ class BNSDashboard {
 				(data.unlinked_pan_count || 0) > 0 ? "warn" : "ok");
 			this._set_metric("health-transfer-mismatch", mismatchCount, null,
 				mismatchCount > 0 ? "danger" : "ok");
+
+			// Update POD metrics
+			this._set_metric("pod-total-pending", data.pod_total_pending, null,
+				data.pod_total_pending > 0 ? "warn" : "ok");
+			this._set_metric("pod-total-done", data.pod_total_done, null, "ok");
+			this._set_metric("pod-total-pending-all-missing", data.pod_total_pending_all_missing, null,
+				data.pod_total_pending_all_missing > 0 ? "danger" : "ok");
+			this._set_metric("pod-total-partial", data.pod_total_partial, null,
+				data.pod_total_partial > 0 ? "warn" : "ok");
 		} catch (e) {
 			console.error("Failed to load summary:", e);
 		}

--- a/business_needed_solutions/business_needed_solutions/page/bns_dashboard/bns_dashboard.py
+++ b/business_needed_solutions/business_needed_solutions/page/bns_dashboard/bns_dashboard.py
@@ -958,6 +958,71 @@ def get_dashboard_summary(company=None):
 	
 	# Get lightweight transfer mismatch info from last prepared report
 	transfer_mismatch_info = get_transfer_mismatch_summary(company)
+
+	# Fetch internal customers to exclude from POD count
+	internal_customers = [
+		c.name for c in frappe.get_all(
+			"Customer",
+			or_filters=[
+				["Customer", "is_internal_customer", "=", 1],
+				["Customer", "is_bns_internal_customer", "=", 1]
+			],
+			fields=["name"]
+		)
+	]
+
+	# Build POD filters
+	pod_where = [
+		"si.docstatus = 1",
+		"si.gst_category != 'Unregistered'"
+	]
+	pod_params = {}
+	if company:
+		pod_where.append("si.company = %(company)s")
+		pod_params["company"] = company
+	if internal_customers:
+		pod_where.append("si.customer NOT IN %(internal_customers)s")
+		pod_params["internal_customers"] = tuple(internal_customers)
+
+	kpi_where = list(pod_where)
+
+	# 1. Total Pending (1+ Missing)
+	pod_where_pending = list(pod_where)
+	pod_where_pending.append("(si.bns_pod_status IS NULL OR si.bns_pod_status = '' OR si.bns_pod_date IS NULL OR si.bns_pod_attachment IS NULL OR si.bns_pod_attachment = '')")
+	
+	pod_total_pending_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) FROM `tabSales Invoice` si WHERE {" AND ".join(pod_where_pending)}
+	""", pod_params)
+	pod_total_pending = pod_total_pending_res[0][0] if pod_total_pending_res else 0
+
+	# 2. Total Done POD: all three fields filled AND status = Delivered
+	pod_total_done_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) FROM `tabSales Invoice` si 
+		WHERE {" AND ".join(kpi_where)}
+		  AND si.bns_pod_status = 'Delivered'
+		  AND si.bns_pod_date IS NOT NULL
+		  AND si.bns_pod_attachment IS NOT NULL 
+		  AND si.bns_pod_attachment != ''
+	""", pod_params)
+	pod_total_done = pod_total_done_res[0][0] if pod_total_done_res else 0
+
+	# 3. Total Pending POD (3 Missing): all 3 fields missing/blank
+	pod_total_pending_all_missing_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) FROM `tabSales Invoice` si 
+		WHERE {" AND ".join(kpi_where)}
+		  AND (si.bns_pod_status IS NULL OR si.bns_pod_status = '')
+		  AND si.bns_pod_date IS NULL
+		  AND (si.bns_pod_attachment IS NULL OR si.bns_pod_attachment = '')
+	""", pod_params)
+	pod_total_pending_all_missing = pod_total_pending_all_missing_res[0][0] if pod_total_pending_all_missing_res else 0
+
+	# 4. Total Partial POD: bns_pod_status = Partially Delivered
+	pod_total_partial_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) FROM `tabSales Invoice` si 
+		WHERE {" AND ".join(kpi_where)}
+		  AND si.bns_pod_status = 'Partially Delivered'
+	""", pod_params)
+	pod_total_partial = pod_total_partial_res[0][0] if pod_total_partial_res else 0
 	
 	return {
 		"items_missing_expense_account": items_missing_count,
@@ -966,6 +1031,10 @@ def get_dashboard_summary(company=None):
 		"transfer_mismatch_count": transfer_mismatch_info.get("count", 0),
 		"transfer_mismatch_prepared_at": transfer_mismatch_info.get("prepared_at"),
 		"transfer_mismatch_status": transfer_mismatch_info.get("status"),
+		"pod_total_pending": pod_total_pending,
+		"pod_total_done": pod_total_done,
+		"pod_total_pending_all_missing": pod_total_pending_all_missing,
+		"pod_total_partial": pod_total_partial,
 		"company": company
 	}
 

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
@@ -68,10 +68,6 @@ class PODDashboard {
 		return this.get_filter_value("customer");
 	}
 
-	get_gst_category() {
-		return this.get_filter_value("gst_category");
-	}
-
 	get_pod_status() {
 		return this.get_filter_value("pod_status");
 	}
@@ -152,12 +148,6 @@ class PODDashboard {
 				label: __("Customer"),
 				fieldtype: "Link",
 				options: "Customer"
-			},
-			{
-				fieldname: "gst_category",
-				label: __("GST Category"),
-				fieldtype: "Select",
-				options: "\nRegistered Regular\nRegistered Composition\nSEZ\nOverseas\nDeemed Export\nUIN Holders\nTax Deductor\nTax Collector\nInput Service Distributor"
 			},
 			{
 				fieldname: "pod_status",
@@ -293,7 +283,6 @@ class PODDashboard {
 				from_date: this.get_from_date(),
 				to_date: this.get_to_date(),
 				customer: this.get_customer(),
-				gst_category: this.get_gst_category(),
 				pod_status: this.get_pod_status(),
 			},
 			callback: function (r) {
@@ -359,20 +348,18 @@ class PODDashboard {
 				<table class="table pod-table">
 					<thead>
 						<tr>
-							<th style="width:130px">${__("Sales Invoice")}</th>
+							<th style="width:220px">${__("Sales Invoice")}</th>
 							<th>${__("Customer")}</th>
-							<th style="width:130px">${__("GST Category")}</th>
 							<th style="width:110px">${__("Date")}</th>
 							<th style="width:115px">${__("Grand Total")}</th>
-							<th style="width:130px">${__("POD Status")}</th>
-							<th style="width:130px">${__("POD Date")}</th>
-							<th style="width:180px">${__("POD Attachment")}</th>
+							<th style="width:130px">${__("Fully Accepted")}</th>
+							<th style="width:140px">${__("POD Date")}</th>
+							<th style="width:200px">${__("POD Attachment")}</th>
 							<th style="width:85px">${__("Action")}</th>
 						</tr>
 						<tr class="pod-search-row">
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="name" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="customer" placeholder="${__("Search…")}"></th>
-							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="gst_category" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="posting_date" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="grand_total" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_status" placeholder="${__("Search…")}"></th>
@@ -391,14 +378,6 @@ class PODDashboard {
 
 			const rowClass = "pod-row-pending";
 
-			// GST Category Badge (Note: 'Unregistered' is excluded in the backend query)
-			let gstBadge = "";
-			if (inv.gst_category) {
-				gstBadge = `<span class="pod-gst-badge gst-registered">${frappe.utils.escape_html(inv.gst_category)}</span>`;
-			} else {
-				gstBadge = `<span class="text-muted" style="font-size:0.75rem;">—</span>`;
-			}
-
 			const escName = frappe.utils.escape_html(inv.name);
 			const escCustomerName = frappe.utils.escape_html(inv.customer_name || inv.customer || "");
 			const escDate = frappe.utils.escape_html(inv.posting_date || "");
@@ -407,29 +386,42 @@ class PODDashboard {
 			const currentStatus = frappe.utils.escape_html(inv.bns_pod_status || "");
 			const currentDate = frappe.utils.escape_html(inv.bns_pod_date || "");
 
+			// PO Details below Sales Invoice
+			let poDetailsHtml = "";
+			if (inv.po_no || inv.po_date) {
+				const escPoNo = inv.po_no ? frappe.utils.escape_html(inv.po_no) : "";
+				const escPoDate = inv.po_date ? frappe.datetime.str_to_user(inv.po_date) : "";
+				poDetailsHtml = `
+					<div class="pod-po-details">
+						<span class="po-label">PO:</span>
+						<span class="po-val">${escPoNo} ${escPoDate ? `(${escPoDate})` : ""}</span>
+					</div>
+				`;
+			}
+
 			html += `
 				<tr class="${rowClass}" data-name="${escName}">
 					<td>
 						<a href="/app/sales-invoice/${escName}" target="_blank" class="pod-si-link">
 							${escName}
 						</a>
+						${poDetailsHtml}
 					</td>
 					<td>
 						<div class="pod-customer-cell">
 							<span class="customer-name" title="${frappe.utils.escape_html(inv.customer || '')}">${escCustomerName}</span>
 						</div>
 					</td>
-					<td>${gstBadge}</td>
 					<td><span class="text-muted">${escDate}</span></td>
 					<td><span class="pod-total-amount">${grandTotal}</span></td>
 					<td>
 						<div class="pod-field-wrap">
-							<select class="form-control form-control-sm pod-status-input ${hasStatus ? 'pod-input-filled' : 'pod-input-missing'}" data-name="${escName}">
-								<option value="">— ${__("Select")} —</option>
-								<option value="Delivered" ${currentStatus === "Delivered" ? "selected" : ""}>${__("Delivered")}</option>
-								<option value="In-Transit" ${currentStatus === "In-Transit" ? "selected" : ""}>${__("In-Transit")}</option>
-								<option value="Issue" ${currentStatus === "Issue" ? "selected" : ""}>${__("Issue")}</option>
-							</select>
+							<div class="pod-checkbox-wrap">
+								<input type="checkbox" class="pod-status-checkbox ${hasStatus ? 'pod-input-filled' : 'pod-input-missing'}" 
+									data-name="${escName}"
+									${currentStatus === "Delivered" ? "checked" : ""}>
+								<label class="pod-checkbox-label">${__("Accepted")}</label>
+							</div>
 						</div>
 					</td>
 					<td>
@@ -506,15 +498,17 @@ class PODDashboard {
 			self.save_pod_row(siName, container, $(this));
 		});
 
-		// Update style on input changes
-		container.off("change", ".pod-status-input").on("change", ".pod-status-input", function () {
-			self.toggle_input_style($(this), !!$(this).val());
+		// Update style on status checkbox changes
+		container.off("change", ".pod-status-checkbox").on("change", ".pod-status-checkbox", function () {
+			self.toggle_input_style($(this), $(this).is(":checked"));
 		});
 
+		// Update style on date input changes
 		container.off("change", ".pod-date-input").on("change", ".pod-date-input", function () {
 			self.toggle_input_style($(this), !!$(this).val());
 		});
 
+		// Update style on attachment input changes
 		container.off("input change", ".pod-attach-input").on("input change", ".pod-attach-input", function () {
 			self.toggle_input_style($(this), !!$(this).val().trim());
 		});
@@ -541,17 +535,16 @@ class PODDashboard {
 			for (const [col, val] of Object.entries(rowFilters)) {
 				let cellText = "";
 				if (col === "name") {
-					cellText = row.find(".pod-si-link").text();
+					// Search invoice name & PO Details
+					cellText = row.find(".pod-si-link").text() + " " + row.find(".pod-po-details").text();
 				} else if (col === "customer") {
 					cellText = row.find(".customer-name").text();
-				} else if (col === "gst_category") {
-					cellText = row.find(".pod-gst-badge").text();
 				} else if (col === "posting_date") {
-					cellText = row.find("td:nth-child(4)").text();
+					cellText = row.find("td:nth-child(3)").text();
 				} else if (col === "grand_total") {
 					cellText = row.find(".pod-total-amount").text();
 				} else if (col === "pod_status") {
-					cellText = row.find(".pod-status-input").val() || "";
+					cellText = row.find(".pod-status-checkbox").is(":checked") ? "delivered accepted" : "missing";
 				} else if (col === "pod_date") {
 					cellText = row.find(".pod-date-input").val() || "";
 				} else if (col === "pod_attachment") {
@@ -578,7 +571,7 @@ class PODDashboard {
 		const self = this;
 		const row = container.find(`tr[data-name="${siName}"]`);
 
-		const pod_status = row.find(".pod-status-input").val();
+		const pod_status = row.find(".pod-status-checkbox").is(":checked") ? "Delivered" : "";
 		const pod_date = row.find(".pod-date-input").val();
 		const pod_attachment = row.find(".pod-attach-input").val().trim();
 
@@ -660,24 +653,33 @@ class PODDashboard {
 	// ── Update inputs in place after partial save ────────────────────
 
 	refresh_row_inputs(row, pod_status, pod_date, pod_attachment) {
-		const statusInput = row.find(".pod-status-input");
+		const statusCheckbox = row.find(".pod-status-checkbox");
 		const dateInput = row.find(".pod-date-input");
 		const attachInput = row.find(".pod-attach-input");
 
-		statusInput.val(pod_status || "");
+		statusCheckbox.prop("checked", pod_status === "Delivered");
 		dateInput.val(pod_date || "");
 		attachInput.val(pod_attachment || "");
 
-		this.toggle_input_style(statusInput, !!pod_status);
+		this.toggle_input_style(statusCheckbox, pod_status === "Delivered");
 		this.toggle_input_style(dateInput, !!pod_date);
 		this.toggle_input_style(attachInput, !!pod_attachment);
 	}
 
 	toggle_input_style(input, is_filled) {
-		if (is_filled) {
-			input.removeClass("pod-input-missing").addClass("pod-input-filled");
+		if (input.is(":checkbox")) {
+			const wrap = input.closest(".pod-checkbox-wrap");
+			if (is_filled) {
+				wrap.removeClass("pod-input-missing").addClass("pod-input-filled");
+			} else {
+				wrap.removeClass("pod-input-filled").addClass("pod-input-missing");
+			}
 		} else {
-			input.removeClass("pod-input-filled").addClass("pod-input-missing");
+			if (is_filled) {
+				input.removeClass("pod-input-missing").addClass("pod-input-filled");
+			} else {
+				input.removeClass("pod-input-filled").addClass("pod-input-missing");
+			}
 		}
 	}
 
@@ -879,7 +881,7 @@ class PODDashboard {
 				background-color: #f8fafc;
 			}
 
-			/* ─── SI Link ───────────────────────────────────────────── */
+			/* ─── SI Link & PO Details ──────────────────────────────── */
 			.pod-si-link {
 				font-weight: 700;
 				color: var(--primary-color, #1f6bff);
@@ -888,27 +890,22 @@ class PODDashboard {
 			.pod-si-link:hover {
 				text-decoration: underline;
 			}
-
-			/* ─── GST Badge ─────────────────────────────────────────── */
-			.pod-gst-badge {
-				display: inline-block;
-				padding: 2px 8px;
-				border-radius: 9999px;
-				font-size: 0.75rem;
+			.pod-po-details {
+				font-size: 0.72rem;
+				color: #64748b;
+				margin-top: 4px;
+				line-height: 1.2;
+			}
+			.po-label {
 				font-weight: 600;
 			}
-			.gst-registered {
-				background-color: #dcfce7;
-				color: #166534;
-			}
 
-			/* ─── Inputs ────────────────────────────────────────────── */
+			/* ─── Inputs & Checkbox ─────────────────────────────────── */
 			.pod-field-wrap {
 				display: flex;
 				flex-direction: column;
 				gap: 4px;
 			}
-			.pod-status-input,
 			.pod-date-input,
 			.pod-attach-input {
 				height: 28px !important;
@@ -916,6 +913,32 @@ class PODDashboard {
 				border-radius: 5px !important;
 				transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 			}
+			
+			/* Checkbox styles */
+			.pod-checkbox-wrap {
+				display: flex;
+				align-items: center;
+				gap: 6px;
+				padding: 3px 8px;
+				border-radius: 5px;
+				height: 28px;
+				width: fit-content;
+			}
+			.pod-status-checkbox {
+				width: 15px;
+				height: 15px;
+				cursor: pointer;
+				margin: 0 !important;
+			}
+			.pod-checkbox-label {
+				font-size: 0.78rem;
+				font-weight: 600;
+				color: #475569;
+				margin: 0;
+				cursor: pointer;
+				user-select: none;
+			}
+
 			.pod-input-missing {
 				border: 1px solid #fecdd3 !important;
 				background-color: #fff1f2 !important;
@@ -924,12 +947,24 @@ class PODDashboard {
 				border: 1px solid #cbd5e1 !important;
 				background-color: #ffffff !important;
 			}
+			
+			/* Add styles for checkbox wrapper specifically */
+			div.pod-checkbox-wrap.pod-input-missing {
+				border: 1px solid #fecdd3 !important;
+				background-color: #fff1f2 !important;
+			}
+			div.pod-checkbox-wrap.pod-input-filled {
+				border: 1px solid #cbd5e1 !important;
+				background-color: #ffffff !important;
+			}
+
 			.pod-input-missing:focus,
 			.pod-input-filled:focus {
 				border-color: #a5b4fc !important;
 				box-shadow: 0 0 0 2px rgba(165, 180, 252, 0.2) !important;
 				outline: 0;
 			}
+			
 			.pod-attach-wrap {
 				display: flex;
 				gap: 4px;

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
@@ -37,7 +37,7 @@ class PODDashboard {
 
 		// Pagination State
 		this.start = 0;
-		this.page_length = 20;
+		this.page_length = 500;
 		this.total = 0;
 
 		this.init();
@@ -903,7 +903,8 @@ class PODDashboard {
 
 			/* ─── Table ─────────────────────────────────────────────── */
 			.pod-table-wrapper {
-				max-height: calc(100vh - 350px);
+				max-height: calc(100vh - 220px);
+				min-height: 500px;
 				overflow-y: auto;
 			}
 			.pod-table {

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
@@ -88,19 +88,19 @@ class PODDashboard {
 				<div class="pod-summary-row" id="pod-summary-row">
 					<div class="pod-metric-card" id="pod-pending-card">
 						<div class="pod-metric-value" id="pod-pending-count">--</div>
-						<div class="pod-metric-label">${__("Total Pending")}</div>
+						<div class="pod-metric-label">${__("Total Pending (1+ Missing)")}</div>
 					</div>
-					<div class="pod-metric-card" id="pod-status-card">
-						<div class="pod-metric-value" id="pod-missing-status-count">--</div>
-						<div class="pod-metric-label">${__("Missing Status")}</div>
+					<div class="pod-metric-card" id="pod-done-card">
+						<div class="pod-metric-value" id="pod-done-count">--</div>
+						<div class="pod-metric-label">${__("Total Done POD")}</div>
 					</div>
-					<div class="pod-metric-card" id="pod-date-card">
-						<div class="pod-metric-value" id="pod-missing-date-count">--</div>
-						<div class="pod-metric-label">${__("Missing Date")}</div>
+					<div class="pod-metric-card" id="pod-all-missing-card">
+						<div class="pod-metric-value" id="pod-all-missing-count">--</div>
+						<div class="pod-metric-label">${__("Total Pending POD (3 Missing)")}</div>
 					</div>
-					<div class="pod-metric-card" id="pod-attach-card">
-						<div class="pod-metric-value" id="pod-missing-attach-count">--</div>
-						<div class="pod-metric-label">${__("Missing Attachment")}</div>
+					<div class="pod-metric-card" id="pod-partial-card">
+						<div class="pod-metric-value" id="pod-partial-count">--</div>
+						<div class="pod-metric-label">${__("Total Partial POD")}</div>
 					</div>
 				</div>
 
@@ -159,7 +159,7 @@ class PODDashboard {
 				fieldname: "pod_status",
 				label: __("POD Status"),
 				fieldtype: "Select",
-				options: "\nMissing\nDelivered\nIn-Transit\nIssue"
+				options: "\nDelivered\nPartially Delivered\nNot Delivered"
 			},
 			{
 				fieldname: "fiscal_year",
@@ -320,9 +320,9 @@ class PODDashboard {
 
 					self.render_summary(
 						r.message.total,
-						r.message.missing_status,
-						r.message.missing_date,
-						r.message.missing_attachment
+						r.message.total_done,
+						r.message.total_pending_all_missing,
+						r.message.total_partial
 					);
 					self.render_table(self.data, container);
 				} else {
@@ -337,16 +337,18 @@ class PODDashboard {
 
 	// ── Summary ──────────────────────────────────────────────────────
 
-	render_summary(total, missing_status, missing_date, missing_attach) {
+	render_summary(total, total_done, total_pending_all_missing, total_partial) {
 		this.wrapper.find("#pod-pending-count").text(total || 0);
-		this.wrapper.find("#pod-missing-status-count").text(missing_status || 0);
-		this.wrapper.find("#pod-missing-date-count").text(missing_date || 0);
-		this.wrapper.find("#pod-missing-attach-count").text(missing_attach || 0);
+		this.wrapper.find("#pod-done-count").text(total_done || 0);
+		this.wrapper.find("#pod-all-missing-count").text(total_pending_all_missing || 0);
+		this.wrapper.find("#pod-partial-count").text(total_partial || 0);
 
 		this.update_card_style(this.wrapper.find("#pod-pending-card"), total || 0);
-		this.update_card_style(this.wrapper.find("#pod-status-card"), missing_status || 0);
-		this.update_card_style(this.wrapper.find("#pod-date-card"), missing_date || 0);
-		this.update_card_style(this.wrapper.find("#pod-attach-card"), missing_attach || 0);
+		this.wrapper.find("#pod-done-card").removeClass("pod-card-ok pod-card-warning pod-card-danger");
+		this.wrapper.find("#pod-done-card").addClass("pod-card-ok");
+
+		this.update_card_style(this.wrapper.find("#pod-all-missing-card"), total_pending_all_missing || 0);
+		this.update_card_style(this.wrapper.find("#pod-partial-card"), total_partial || 0);
 	}
 
 	update_card_style(card, count) {
@@ -401,8 +403,7 @@ class PODDashboard {
 									<th style="width:220px">${__("Sales Invoice")}</th>
 									<th>${__("Customer")}</th>
 									<th style="width:110px">${__("Date")}</th>
-									<th style="width:115px">${__("Grand Total")}</th>
-									<th style="width:130px">${__("Fully Accepted")}</th>
+									<th style="width:160px">${__("POD Status")}</th>
 									<th style="width:140px">${__("POD Date")}</th>
 									<th style="width:200px">${__("POD Attachment")}</th>
 									<th style="width:85px">${__("Action")}</th>
@@ -411,7 +412,6 @@ class PODDashboard {
 									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="name" placeholder="${__("Search…")}"></th>
 									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="customer" placeholder="${__("Search…")}"></th>
 									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="posting_date" placeholder="${__("Search…")}"></th>
-									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="grand_total" placeholder="${__("Search…")}"></th>
 									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_status" placeholder="${__("Search…")}"></th>
 									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_date" placeholder="${__("Search…")}"></th>
 									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_attachment" placeholder="${__("Search…")}"></th>
@@ -420,7 +420,7 @@ class PODDashboard {
 							</thead>
 							<tbody>
 								<tr>
-									<td colspan="8" class="text-center text-muted">${__("No matching records found")}</td>
+									<td colspan="7" class="text-center text-muted">${__("No matching records found")}</td>
 								</tr>
 							</tbody>
 						</table>
@@ -454,8 +454,7 @@ class PODDashboard {
 							<th style="width:220px">${__("Sales Invoice")}</th>
 							<th>${__("Customer")}</th>
 							<th style="width:110px">${__("Date")}</th>
-							<th style="width:115px">${__("Grand Total")}</th>
-							<th style="width:130px">${__("Fully Accepted")}</th>
+							<th style="width:160px">${__("POD Status")}</th>
 							<th style="width:140px">${__("POD Date")}</th>
 							<th style="width:200px">${__("POD Attachment")}</th>
 							<th style="width:85px">${__("Action")}</th>
@@ -464,7 +463,6 @@ class PODDashboard {
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="name" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="customer" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="posting_date" placeholder="${__("Search…")}"></th>
-							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="grand_total" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_status" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_date" placeholder="${__("Search…")}"></th>
 							<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_attachment" placeholder="${__("Search…")}"></th>
@@ -484,7 +482,6 @@ class PODDashboard {
 			const escName = frappe.utils.escape_html(inv.name);
 			const escCustomerName = frappe.utils.escape_html(inv.customer_name || inv.customer || "");
 			const escDate = frappe.utils.escape_html(inv.posting_date || "");
-			const grandTotal = format_currency(inv.grand_total, inv.currency);
 			const currentAttach = frappe.utils.escape_html(inv.bns_pod_attachment || "");
 			const currentStatus = frappe.utils.escape_html(inv.bns_pod_status || "");
 			const currentDate = frappe.utils.escape_html(inv.bns_pod_date || "");
@@ -495,9 +492,21 @@ class PODDashboard {
 				const escPoNo = inv.po_no ? frappe.utils.escape_html(inv.po_no) : "";
 				const escPoDate = inv.po_date ? frappe.datetime.str_to_user(inv.po_date) : "";
 				poDetailsHtml = `
-					<div class="pod-po-details">
-						<span class="po-label">PO:</span>
-						<span class="po-val">${escPoNo} ${escPoDate ? `(${escPoDate})` : ""}</span>
+					<div class="pod-invoice-sub-row">
+						<span class="sub-label">PO:</span>
+						<span class="sub-val">${escPoNo} ${escPoDate ? `(${escPoDate})` : ""}</span>
+					</div>
+				`;
+			}
+
+			// SO Details below Sales Invoice
+			let soDetailsHtml = "";
+			if (inv.sales_orders) {
+				const escSalesOrders = frappe.utils.escape_html(inv.sales_orders);
+				soDetailsHtml = `
+					<div class="pod-invoice-sub-row">
+						<span class="sub-label">SO:</span>
+						<span class="sub-val" title="${escSalesOrders}">${escSalesOrders}</span>
 					</div>
 				`;
 			}
@@ -508,23 +517,31 @@ class PODDashboard {
 						<a href="/app/sales-invoice/${escName}" target="_blank" class="pod-si-link">
 							${escName}
 						</a>
-						${poDetailsHtml}
+						<div class="pod-invoice-sub-info">
+							${soDetailsHtml}
+							${poDetailsHtml}
+						</div>
 					</td>
 					<td>
 						<div class="pod-customer-cell">
 							<span class="customer-name" title="${frappe.utils.escape_html(inv.customer || '')}">${escCustomerName}</span>
+							${(inv.city || inv.state) ? `
+								<div class="pod-customer-address">
+									${[inv.city, inv.state].filter(Boolean).map(frappe.utils.escape_html).join(", ")}
+								</div>
+							` : ""}
 						</div>
 					</td>
 					<td><span class="text-muted">${escDate}</span></td>
-					<td><span class="pod-total-amount">${grandTotal}</span></td>
 					<td>
 						<div class="pod-field-wrap">
-							<div class="pod-checkbox-wrap">
-								<input type="checkbox" class="pod-status-checkbox ${hasStatus ? 'pod-input-filled' : 'pod-input-missing'}" 
-									data-name="${escName}"
-									${currentStatus === "Delivered" ? "checked" : ""}>
-								<label class="pod-checkbox-label">${__("Accepted")}</label>
-							</div>
+							<select class="form-control form-control-sm pod-status-select ${hasStatus ? 'pod-input-filled' : 'pod-input-missing'}"
+								data-name="${escName}">
+								<option value="">${__("Select...")}</option>
+								<option value="Delivered" ${currentStatus === "Delivered" ? "selected" : ""}>${__("Delivered")}</option>
+								<option value="Partially Delivered" ${currentStatus === "Partially Delivered" ? "selected" : ""}>${__("Partially Delivered")}</option>
+								<option value="Not Delivered" ${currentStatus === "Not Delivered" ? "selected" : ""}>${__("Not Delivered")}</option>
+							</select>
 						</div>
 					</td>
 					<td>
@@ -646,9 +663,9 @@ class PODDashboard {
 			self.save_pod_row(siName, container, $(this));
 		});
 
-		// Update style on status checkbox changes
-		container.off("change", ".pod-status-checkbox").on("change", ".pod-status-checkbox", function () {
-			self.toggle_input_style($(this), $(this).is(":checked"));
+		// Update style on status select changes
+		container.off("change", ".pod-status-select").on("change", ".pod-status-select", function () {
+			self.toggle_input_style($(this), !!$(this).val());
 		});
 
 		// Update style on date input changes
@@ -668,7 +685,7 @@ class PODDashboard {
 		const self = this;
 		const row = container.find(`tr[data-name="${siName}"]`);
 
-		const pod_status = row.find(".pod-status-checkbox").is(":checked") ? "Delivered" : "";
+		const pod_status = row.find(".pod-status-select").val();
 		const pod_date = row.find(".pod-date-input").val();
 		const pod_attachment = row.find(".pod-attach-input").val().trim();
 
@@ -735,15 +752,15 @@ class PODDashboard {
 	// ── Update inputs in place after partial save ────────────────────
 
 	refresh_row_inputs(row, pod_status, pod_date, pod_attachment) {
-		const statusCheckbox = row.find(".pod-status-checkbox");
+		const statusSelect = row.find(".pod-status-select");
 		const dateInput = row.find(".pod-date-input");
 		const attachInput = row.find(".pod-attach-input");
 
-		statusCheckbox.prop("checked", pod_status === "Delivered");
+		statusSelect.val(pod_status || "");
 		dateInput.val(pod_date || "");
 		attachInput.val(pod_attachment || "");
 
-		this.toggle_input_style(statusCheckbox, pod_status === "Delivered");
+		this.toggle_input_style(statusSelect, !!pod_status);
 		this.toggle_input_style(dateInput, !!pod_date);
 		this.toggle_input_style(attachInput, !!pod_attachment);
 	}
@@ -964,7 +981,7 @@ class PODDashboard {
 				background-color: #f8fafc;
 			}
 
-			/* ─── SI Link & PO Details ──────────────────────────────── */
+			/* ─── SI Link & PO / SO Details ────────────────────────── */
 			.pod-si-link {
 				font-weight: 700;
 				color: var(--primary-color, #1f6bff);
@@ -973,21 +990,51 @@ class PODDashboard {
 			.pod-si-link:hover {
 				text-decoration: underline;
 			}
-			.pod-po-details {
+			.pod-invoice-sub-info {
+				display: flex;
+				flex-direction: column;
+				gap: 2px;
+				margin-top: 4px;
+			}
+			.pod-invoice-sub-row {
 				font-size: 0.72rem;
 				color: #64748b;
-				margin-top: 4px;
 				line-height: 1.2;
+				display: flex;
+				gap: 4px;
+				align-items: center;
 			}
-			.po-label {
-				font-weight: 600;
+			.sub-label {
+				font-weight: 700;
+				color: #475569;
+			}
+			.sub-val {
+				color: #64748b;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				max-width: 180px;
+			}
+			.pod-customer-address {
+				font-size: 0.72rem;
+				color: #64748b;
+				font-style: italic;
+				margin-top: 2px;
 			}
 
-			/* ─── Inputs & Checkbox ─────────────────────────────────── */
+			/* ─── Inputs & Status Select ────────────────────────────── */
 			.pod-field-wrap {
 				display: flex;
 				flex-direction: column;
 				gap: 4px;
+			}
+			.pod-status-select {
+				height: 28px !important;
+				font-size: 0.78rem !important;
+				border-radius: 5px !important;
+				padding: 2px 6px !important;
+				font-weight: 600;
+				cursor: pointer;
 			}
 			.pod-date-input,
 			.pod-attach-input {
@@ -995,31 +1042,6 @@ class PODDashboard {
 				font-size: 0.78rem !important;
 				border-radius: 5px !important;
 				transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-			}
-			
-			/* Checkbox styles */
-			.pod-checkbox-wrap {
-				display: flex;
-				align-items: center;
-				gap: 6px;
-				padding: 3px 8px;
-				border-radius: 5px;
-				height: 28px;
-				width: fit-content;
-			}
-			.pod-status-checkbox {
-				width: 15px;
-				height: 15px;
-				cursor: pointer;
-				margin: 0 !important;
-			}
-			.pod-checkbox-label {
-				font-size: 0.78rem;
-				font-weight: 600;
-				color: #475569;
-				margin: 0;
-				cursor: pointer;
-				user-select: none;
 			}
 
 			.pod-input-missing {
@@ -1031,15 +1053,7 @@ class PODDashboard {
 				background-color: #ffffff !important;
 			}
 			
-			/* Add styles for checkbox wrapper specifically */
-			div.pod-checkbox-wrap.pod-input-missing {
-				border: 1px solid #fecdd3 !important;
-				background-color: #fff1f2 !important;
-			}
-			div.pod-checkbox-wrap.pod-input-filled {
-				border: 1px solid #cbd5e1 !important;
-				background-color: #ffffff !important;
-			}
+			/* Focus styles for status select and inputs */
 
 			.pod-input-missing:focus,
 			.pod-input-filled:focus {

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.js
@@ -34,6 +34,12 @@ class PODDashboard {
 		this.data = [];
 		this.filters = {};
 		this.in_filter_change = false;
+
+		// Pagination State
+		this.start = 0;
+		this.page_length = 20;
+		this.total = 0;
+
 		this.init();
 	}
 
@@ -243,19 +249,23 @@ class PODDashboard {
 									self.filters.to_date.set_value(r.message.year_end_date);
 								}
 								self.in_filter_change = false;
+								self.start = 0; // Reset pagination
 								self.refresh();
 							} else {
 								self.in_filter_change = false;
+								self.start = 0; // Reset pagination
 								self.refresh();
 							}
 						});
 					} else {
+						self.start = 0; // Reset pagination
 						self.refresh();
 					}
 				};
 			} else {
 				control.df.change = function() {
 					if (!self.in_filter_change) {
+						self.start = 0; // Reset pagination
 						self.refresh();
 					}
 				};
@@ -268,12 +278,27 @@ class PODDashboard {
 	refresh() {
 		const self = this;
 		const container = this.wrapper.find("#pod-table-container");
-		container.html(`
-			<div class="pod-loading">
-				<span class="spinner-border spinner-border-sm"></span>
-				${__("Loading…")}
-			</div>
-		`);
+
+		// Show loading spinner but preserve existing table structure to avoid UI jump if possible
+		const hasTable = container.find("table").length > 0;
+		if (!hasTable) {
+			container.html(`
+				<div class="pod-loading">
+					<span class="spinner-border spinner-border-sm"></span>
+					${__("Loading…")}
+				</div>
+			`);
+		}
+
+		// Read quick column search inputs
+		const search_args = {};
+		container.find(".pod-search-input").each(function () {
+			const col = $(this).data("col");
+			const val = $(this).val().trim();
+			if (val) {
+				search_args[`search_${col}`] = val;
+			}
+		});
 
 		frappe.call({
 			method: "business_needed_solutions.business_needed_solutions.page.pod_dashboard.pod_dashboard.get_pending_pod_invoices",
@@ -284,11 +309,21 @@ class PODDashboard {
 				to_date: this.get_to_date(),
 				customer: this.get_customer(),
 				pod_status: this.get_pod_status(),
+				start: this.start,
+				page_length: this.page_length,
+				...search_args
 			},
 			callback: function (r) {
 				if (r && r.message) {
 					self.data = r.message.invoices || [];
-					self.render_summary();
+					self.total = r.message.total || 0;
+
+					self.render_summary(
+						r.message.total,
+						r.message.missing_status,
+						r.message.missing_date,
+						r.message.missing_attachment
+					);
 					self.render_table(self.data, container);
 				} else {
 					container.html(`<div class="pod-empty">${__("No data returned.")}</div>`);
@@ -302,21 +337,16 @@ class PODDashboard {
 
 	// ── Summary ──────────────────────────────────────────────────────
 
-	render_summary() {
-		const total = this.data.length;
-		const missing_status = this.data.filter(d => !d.bns_pod_status).length;
-		const missing_date = this.data.filter(d => !d.bns_pod_date).length;
-		const missing_attach = this.data.filter(d => !d.bns_pod_attachment).length;
+	render_summary(total, missing_status, missing_date, missing_attach) {
+		this.wrapper.find("#pod-pending-count").text(total || 0);
+		this.wrapper.find("#pod-missing-status-count").text(missing_status || 0);
+		this.wrapper.find("#pod-missing-date-count").text(missing_date || 0);
+		this.wrapper.find("#pod-missing-attach-count").text(missing_attach || 0);
 
-		this.wrapper.find("#pod-pending-count").text(total);
-		this.wrapper.find("#pod-missing-status-count").text(missing_status);
-		this.wrapper.find("#pod-missing-date-count").text(missing_date);
-		this.wrapper.find("#pod-missing-attach-count").text(missing_attach);
-
-		this.update_card_style(this.wrapper.find("#pod-pending-card"), total);
-		this.update_card_style(this.wrapper.find("#pod-status-card"), missing_status);
-		this.update_card_style(this.wrapper.find("#pod-date-card"), missing_date);
-		this.update_card_style(this.wrapper.find("#pod-attach-card"), missing_attach);
+		this.update_card_style(this.wrapper.find("#pod-pending-card"), total || 0);
+		this.update_card_style(this.wrapper.find("#pod-status-card"), missing_status || 0);
+		this.update_card_style(this.wrapper.find("#pod-date-card"), missing_date || 0);
+		this.update_card_style(this.wrapper.find("#pod-attach-card"), missing_attach || 0);
 	}
 
 	update_card_style(card, count) {
@@ -333,13 +363,86 @@ class PODDashboard {
 	// ── Table ────────────────────────────────────────────────────────
 
 	render_table(invoices, container) {
+		const self = this;
+
+		// Save current search input values and focus state
+		const search_vals = {};
+		container.find(".pod-search-input").each(function () {
+			const col = $(this).data("col");
+			search_vals[col] = $(this).val();
+		});
+
+		const active_input = document.activeElement;
+		let active_col = null;
+		let selection_start = null;
+		let selection_end = null;
+		if (active_input && $(active_input).hasClass("pod-search-input")) {
+			active_col = $(active_input).data("col");
+			selection_start = active_input.selectionStart;
+			selection_end = active_input.selectionEnd;
+		}
+
 		if (!invoices || invoices.length === 0) {
-			container.html(`
+			let emptyHtml = `
 				<div class="pod-empty">
 					<i class="fa fa-check-circle text-success" style="font-size:2rem;"></i>
-					<p>${__("All Sales Invoices have complete POD details. Great job!")}</p>
+					<p>${__("No pending Sales Invoices match your filters. Great job!")}</p>
 				</div>
-			`);
+			`;
+			
+			// Keep headers if search values were typed
+			const hasSearchActive = Object.values(search_vals).some(val => !!val);
+			if (hasSearchActive) {
+				emptyHtml = `
+					<div class="pod-table-wrapper">
+						<table class="table pod-table">
+							<thead>
+								<tr>
+									<th style="width:220px">${__("Sales Invoice")}</th>
+									<th>${__("Customer")}</th>
+									<th style="width:110px">${__("Date")}</th>
+									<th style="width:115px">${__("Grand Total")}</th>
+									<th style="width:130px">${__("Fully Accepted")}</th>
+									<th style="width:140px">${__("POD Date")}</th>
+									<th style="width:200px">${__("POD Attachment")}</th>
+									<th style="width:85px">${__("Action")}</th>
+								</tr>
+								<tr class="pod-search-row">
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="name" placeholder="${__("Search…")}"></th>
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="customer" placeholder="${__("Search…")}"></th>
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="posting_date" placeholder="${__("Search…")}"></th>
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="grand_total" placeholder="${__("Search…")}"></th>
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_status" placeholder="${__("Search…")}"></th>
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_date" placeholder="${__("Search…")}"></th>
+									<th><input type="text" class="form-control form-control-sm pod-search-input" data-col="pod_attachment" placeholder="${__("Search…")}"></th>
+									<th></th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td colspan="8" class="text-center text-muted">${__("No matching records found")}</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				`;
+			}
+			
+			container.html(emptyHtml);
+
+			// Restore search values & focus
+			Object.entries(search_vals).forEach(([col, val]) => {
+				if (val) container.find(`.pod-search-input[data-col="${col}"]`).val(val);
+			});
+			if (active_col) {
+				const input = container.find(`.pod-search-input[data-col="${active_col}"]`);
+				if (input.length) {
+					input.focus();
+					try { input[0].setSelectionRange(selection_start, selection_end); } catch(e) {}
+				}
+			}
+
+			this.bind_events(container);
 			return;
 		}
 
@@ -455,7 +558,37 @@ class PODDashboard {
 		});
 
 		html += `</tbody></table></div>`;
+
+		// Add Pagination HTML Row
+		const startIdx = this.start + 1;
+		const endIdx = Math.min(this.start + this.page_length, this.total);
+		html += `
+			<div class="pod-pagination-row">
+				<button class="btn btn-default btn-xs btn-pod-prev" ${this.start === 0 ? "disabled" : ""}>
+					<i class="fa fa-chevron-left"></i> ${__("Previous")}
+				</button>
+				<span class="pod-pagination-text">
+					${__("Showing {0} to {1} of {2} records", [startIdx, endIdx, this.total])}
+				</span>
+				<button class="btn btn-default btn-xs btn-pod-next" ${this.start + this.page_length >= this.total ? "disabled" : ""}>
+					${__("Next")} <i class="fa fa-chevron-right"></i>
+				</button>
+			</div>
+		`;
+
 		container.html(html);
+
+		// Restore search input values & focus state
+		Object.entries(search_vals).forEach(([col, val]) => {
+			if (val) container.find(`.pod-search-input[data-col="${col}"]`).val(val);
+		});
+		if (active_col) {
+			const input = container.find(`.pod-search-input[data-col="${active_col}"]`);
+			if (input.length) {
+				input.focus();
+				try { input[0].setSelectionRange(selection_start, selection_end); } catch(e) {}
+			}
+		}
 
 		this.bind_events(container);
 	}
@@ -465,9 +598,24 @@ class PODDashboard {
 	bind_events(container) {
 		const self = this;
 
-		// Quick Search inputs
+		// Quick Search inputs with Server-Side Debounce
+		let search_timeout = null;
 		container.off("input", ".pod-search-input").on("input", ".pod-search-input", function () {
-			self.apply_search_filters(container);
+			clearTimeout(search_timeout);
+			search_timeout = setTimeout(function() {
+				self.start = 0; // Reset pagination on filter change
+				self.refresh();
+			}, 450); // 450ms debounce
+		});
+
+		// Pagination Buttons
+		container.find(".btn-pod-prev").off("click").on("click", function() {
+			self.start = Math.max(0, self.start - self.page_length);
+			self.refresh();
+		});
+		container.find(".btn-pod-next").off("click").on("click", function() {
+			self.start = self.start + self.page_length;
+			self.refresh();
 		});
 
 		// File Upload Button
@@ -514,57 +662,6 @@ class PODDashboard {
 		});
 	}
 
-	// ── Apply Client-Side Search Filters ──────────────────────────────
-
-	apply_search_filters(container) {
-		const rowFilters = {};
-		container.find(".pod-search-input").each(function () {
-			const col = $(this).data("col");
-			const val = $(this).val().toLowerCase().trim();
-			if (val) {
-				rowFilters[col] = val;
-			}
-		});
-
-		const rows = container.find("#pod-table-body tr");
-		
-		rows.each(function () {
-			const row = $(this);
-			let matches = true;
-
-			for (const [col, val] of Object.entries(rowFilters)) {
-				let cellText = "";
-				if (col === "name") {
-					// Search invoice name & PO Details
-					cellText = row.find(".pod-si-link").text() + " " + row.find(".pod-po-details").text();
-				} else if (col === "customer") {
-					cellText = row.find(".customer-name").text();
-				} else if (col === "posting_date") {
-					cellText = row.find("td:nth-child(3)").text();
-				} else if (col === "grand_total") {
-					cellText = row.find(".pod-total-amount").text();
-				} else if (col === "pod_status") {
-					cellText = row.find(".pod-status-checkbox").is(":checked") ? "delivered accepted" : "missing";
-				} else if (col === "pod_date") {
-					cellText = row.find(".pod-date-input").val() || "";
-				} else if (col === "pod_attachment") {
-					cellText = row.find(".pod-attach-input").val() || "";
-				}
-
-				if (!cellText.toLowerCase().includes(val)) {
-					matches = false;
-					break;
-				}
-			}
-
-			if (matches) {
-				row.show();
-			} else {
-				row.hide();
-			}
-		});
-	}
-
 	// ── Save Row ─────────────────────────────────────────────────────
 
 	save_pod_row(siName, container, btn) {
@@ -604,16 +701,9 @@ class PODDashboard {
 							indicator: "green",
 						});
 						
-						// Remove item from local data array
-						self.data = self.data.filter(d => d.name !== siName);
-
 						row.css("transition", "all 0.5s").css("opacity", "0").css("background-color", "#d4edda");
 						setTimeout(function () {
-							row.remove();
-							self.render_summary();
-							if (self.data.length === 0) {
-								self.render_table([], container);
-							}
+							self.refresh(); // Reload current page list to pull new record into pagination view
 						}, 500);
 					} else {
 						// Partial save — update inputs and classes
@@ -622,16 +712,8 @@ class PODDashboard {
 							indicator: "blue",
 						});
 						
-						// Update local data
-						const item = self.data.find(d => d.name === siName);
-						if (item) {
-							item.bns_pod_status = pod_status;
-							item.bns_pod_date = pod_date;
-							item.bns_pod_attachment = pod_attachment;
-						}
-
 						self.refresh_row_inputs(row, pod_status, pod_date, pod_attachment);
-						self.render_summary();
+						self.refresh(); // Reload statistics and lists
 					}
 				} else {
 					frappe.show_alert({
@@ -821,7 +903,7 @@ class PODDashboard {
 
 			/* ─── Table ─────────────────────────────────────────────── */
 			.pod-table-wrapper {
-				max-height: calc(100vh - 300px);
+				max-height: calc(100vh - 350px);
 				overflow-y: auto;
 			}
 			.pod-table {
@@ -995,6 +1077,28 @@ class PODDashboard {
 			.btn-pod-save {
 				height: 28px;
 				padding: 0 10px !important;
+				font-weight: 600;
+				border-radius: 5px !important;
+				font-size: 0.78rem !important;
+			}
+
+			/* ─── Pagination ────────────────────────────────────────── */
+			.pod-pagination-row {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 12px 20px;
+				border-top: 1px solid #e2e8f0;
+				background-color: #f8fafc;
+			}
+			.pod-pagination-text {
+				font-size: 0.78rem;
+				font-weight: 600;
+				color: #475569;
+			}
+			.btn-pod-prev, .btn-pod-next {
+				height: 28px;
+				padding: 0 12px !important;
 				font-weight: 600;
 				border-radius: 5px !important;
 				font-size: 0.78rem !important;

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
@@ -110,109 +110,143 @@ def get_pending_pod_invoices(
 		)
 	]
 
-	# Build base filters — always submitted, always for selected company, and always exclude Unregistered GST category
-	filters = [
-		["Sales Invoice", "docstatus", "=", 1],
-		["Sales Invoice", "gst_category", "!=", "Unregistered"]
+	# Build base SQL filters
+	where_conds = [
+		"si.docstatus = 1",
+		"si.gst_category != 'Unregistered'"
 	]
+	params = {}
+
 	if company:
-		filters.append(["Sales Invoice", "company", "=", company])
+		where_conds.append("si.company = %(company)s")
+		params["company"] = company
 	
 	if internal_customers:
-		filters.append(["Sales Invoice", "customer", "not in", internal_customers])
+		where_conds.append("si.customer NOT IN %(internal_customers)s")
+		params["internal_customers"] = tuple(internal_customers)
 
 	if from_date:
-		filters.append(["Sales Invoice", "posting_date", ">=", from_date])
+		where_conds.append("si.posting_date >= %(from_date)s")
+		params["from_date"] = from_date
 	if to_date:
-		filters.append(["Sales Invoice", "posting_date", "<=", to_date])
+		where_conds.append("si.posting_date <= %(to_date)s")
+		params["to_date"] = to_date
 
 	if customer:
-		filters.append(["Sales Invoice", "customer", "=", customer])
+		where_conds.append("si.customer = %(customer)s")
+		params["customer"] = customer
 
 	if pod_status:
 		if pod_status == "Missing":
-			filters.append(["Sales Invoice", "bns_pod_status", "in", ["", None]])
+			where_conds.append("(si.bns_pod_status IS NULL OR si.bns_pod_status = '')")
 		else:
-			filters.append(["Sales Invoice", "bns_pod_status", "=", pod_status])
+			where_conds.append("si.bns_pod_status = %(pod_status)s")
+			params["pod_status"] = pod_status
 
 	# Add quick column searches
 	if search_name:
-		filters.append(["Sales Invoice", "name", "like", f"%{search_name}%"])
+		where_conds.append("si.name LIKE %(search_name)s")
+		params["search_name"] = f"%{search_name}%"
 	if search_customer:
-		filters.append(["Sales Invoice", "customer_name", "like", f"%{search_customer}%"])
+		where_conds.append("si.customer_name LIKE %(search_customer)s")
+		params["search_customer"] = f"%{search_customer}%"
 	if search_posting_date:
-		filters.append(["Sales Invoice", "posting_date", "like", f"%{search_posting_date}%"])
-	if search_grand_total:
-		filters.append(["Sales Invoice", "grand_total", "like", f"%{search_grand_total}%"])
+		where_conds.append("si.posting_date LIKE %(search_posting_date)s")
+		params["search_posting_date"] = f"%{search_posting_date}%"
 	if search_pod_status:
-		filters.append(["Sales Invoice", "bns_pod_status", "like", f"%{search_pod_status}%"])
+		where_conds.append("si.bns_pod_status LIKE %(search_pod_status)s")
+		params["search_pod_status"] = f"%{search_pod_status}%"
 	if search_pod_date:
-		filters.append(["Sales Invoice", "bns_pod_date", "like", f"%{search_pod_date}%"])
+		where_conds.append("si.bns_pod_date LIKE %(search_pod_date)s")
+		params["search_pod_date"] = f"%{search_pod_date}%"
 	if search_pod_attachment:
-		filters.append(["Sales Invoice", "bns_pod_attachment", "like", f"%{search_pod_attachment}%"])
+		where_conds.append("si.bns_pod_attachment LIKE %(search_pod_attachment)s")
+		params["search_pod_attachment"] = f"%{search_pod_attachment}%"
+
+	# Save KPI filters before applying the main dashboard pending condition
+	kpi_where_conds = list(where_conds)
 
 	# Base pending OR filters — at least one of the 3 fields must be missing
-	or_filters = [
-		["Sales Invoice", "bns_pod_status", "in", ["", None]],
-		["Sales Invoice", "bns_pod_date", "is", "not set"],
-		["Sales Invoice", "bns_pod_attachment", "in", ["", None]]
-	]
+	where_conds.append("(si.bns_pod_status IS NULL OR si.bns_pod_status = '' OR si.bns_pod_date IS NULL OR si.bns_pod_attachment IS NULL OR si.bns_pod_attachment = '')")
 
-	# Query matching records for current page
-	invoices = frappe.get_all(
-		"Sales Invoice",
-		filters=filters,
-		or_filters=or_filters,
-		fields=[
-			"name",
-			"customer",
-			"customer_name",
-			"posting_date",
-			"grand_total",
-			"currency",
-			"bns_pod_status",
-			"bns_pod_date",
-			"bns_pod_attachment",
-			"po_no",
-			"po_date"
-		],
-		order_by="posting_date desc",
-		start=start,
-		page_length=page_length
-	)
+	# Query matching records for current page using raw SQL with JOIN and subquery
+	query = f"""
+		SELECT 
+			si.name,
+			si.customer,
+			si.customer_name,
+			si.posting_date,
+			si.grand_total,
+			si.currency,
+			si.bns_pod_status,
+			si.bns_pod_date,
+			si.bns_pod_attachment,
+			si.po_no,
+			si.po_date,
+			addr.city,
+			addr.state,
+			(SELECT GROUP_CONCAT(DISTINCT sii.sales_order SEPARATOR ', ') 
+			 FROM `tabSales Invoice Item` sii 
+			 WHERE sii.parent = si.name AND sii.sales_order IS NOT NULL AND sii.sales_order != '') as sales_orders
+		FROM `tabSales Invoice` si
+		LEFT JOIN `tabAddress` addr ON si.customer_address = addr.name
+		WHERE {" AND ".join(where_conds)}
+		ORDER BY si.posting_date DESC
+		LIMIT {start}, {page_length}
+	"""
+	invoices = frappe.db.sql(query, params, as_dict=True)
 
 	# Calculate counts dynamically at database level
-	total_pending = frappe.get_all(
-		"Sales Invoice",
-		filters=filters,
-		or_filters=or_filters,
-		fields=["count(name) as total"]
-	)[0].total
+	# Total Pending (at least one missing)
+	total_pending_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) as total 
+		FROM `tabSales Invoice` si
+		LEFT JOIN `tabAddress` addr ON si.customer_address = addr.name
+		WHERE {" AND ".join(where_conds)}
+	""", params)
+	total_pending = total_pending_res[0][0] if total_pending_res else 0
 
-	missing_status = frappe.get_all(
-		"Sales Invoice",
-		filters=filters + [["Sales Invoice", "bns_pod_status", "in", ["", None]]],
-		fields=["count(name) as total"]
-	)[0].total
+	# 1. Total Done POD: all three fields filled AND status = Delivered
+	total_done_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) as total 
+		FROM `tabSales Invoice` si
+		LEFT JOIN `tabAddress` addr ON si.customer_address = addr.name
+		WHERE {" AND ".join(kpi_where_conds)}
+		  AND si.bns_pod_status = 'Delivered'
+		  AND si.bns_pod_date IS NOT NULL
+		  AND si.bns_pod_attachment IS NOT NULL 
+		  AND si.bns_pod_attachment != ''
+	""", params)
+	total_done = total_done_res[0][0] if total_done_res else 0
 
-	missing_date = frappe.get_all(
-		"Sales Invoice",
-		filters=filters + [["Sales Invoice", "bns_pod_date", "is", "not set"]],
-		fields=["count(name) as total"]
-	)[0].total
+	# 2. Total Pending POD: all 3 fields missing/blank
+	total_pending_all_missing_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) as total 
+		FROM `tabSales Invoice` si
+		LEFT JOIN `tabAddress` addr ON si.customer_address = addr.name
+		WHERE {" AND ".join(kpi_where_conds)}
+		  AND (si.bns_pod_status IS NULL OR si.bns_pod_status = '')
+		  AND si.bns_pod_date IS NULL
+		  AND (si.bns_pod_attachment IS NULL OR si.bns_pod_attachment = '')
+	""", params)
+	total_pending_all_missing = total_pending_all_missing_res[0][0] if total_pending_all_missing_res else 0
 
-	missing_attach = frappe.get_all(
-		"Sales Invoice",
-		filters=filters + [["Sales Invoice", "bns_pod_attachment", "in", ["", None]]],
-		fields=["count(name) as total"]
-	)[0].total
+	# 3. Total Partial POD: bns_pod_status = Partially Delivered
+	total_partial_res = frappe.db.sql(f"""
+		SELECT COUNT(si.name) as total 
+		FROM `tabSales Invoice` si
+		LEFT JOIN `tabAddress` addr ON si.customer_address = addr.name
+		WHERE {" AND ".join(kpi_where_conds)}
+		  AND si.bns_pod_status = 'Partially Delivered'
+	""", params)
+	total_partial = total_partial_res[0][0] if total_partial_res else 0
 
 	return {
 		"invoices": invoices,
 		"total": total_pending,
-		"missing_status": missing_status,
-		"missing_date": missing_date,
-		"missing_attachment": missing_attach,
+		"total_done": total_done,
+		"total_pending_all_missing": total_pending_all_missing,
+		"total_partial": total_partial,
 	}
 
 
@@ -229,7 +263,7 @@ def save_pod_details(sales_invoice, pod_status=None, pod_date=None, pod_attachme
 
 	Args:
 		sales_invoice (str): Name of the Sales Invoice
-		pod_status (str): One of: Delivered, In-Transit, Issue (or blank)
+		pod_status (str): One of: Delivered, Partially Delivered, Not Delivered (or blank)
 		pod_date (str): Date string YYYY-MM-DD (or blank)
 		pod_attachment (str): URL/path of the attachment (or blank)
 
@@ -242,7 +276,7 @@ def save_pod_details(sales_invoice, pod_status=None, pod_date=None, pod_attachme
 		frappe.throw(_("Sales Invoice {0} not found.").format(sales_invoice))
 
 	# Validate pod_status is one of allowed values if provided
-	allowed_statuses = ["", "Delivered", "In-Transit", "Issue"]
+	allowed_statuses = ["", "Delivered", "Partially Delivered", "Not Delivered"]
 	if pod_status and pod_status not in allowed_statuses:
 		frappe.throw(_("Invalid POD Status: {0}").format(pod_status))
 

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
@@ -67,7 +67,7 @@ def get_pending_pod_invoices(
 	customer=None,
 	pod_status=None,
 	start=0,
-	page_length=20,
+	page_length=500,
 	search_name=None,
 	search_customer=None,
 	search_posting_date=None,
@@ -88,7 +88,7 @@ def get_pending_pod_invoices(
 
 	company = company or _default_company()
 	start = frappe.utils.cint(start)
-	page_length = frappe.utils.cint(page_length) or 20
+	page_length = frappe.utils.cint(page_length) or 500
 	
 	if fiscal_year and not (from_date and to_date):
 		year_start_date, year_end_date = frappe.db.get_value(

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
@@ -59,7 +59,7 @@ def _default_company():
 
 
 @frappe.whitelist()
-def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_date=None, customer=None, gst_category=None, pod_status=None):
+def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_date=None, customer=None, pod_status=None):
 	"""
 	Return submitted Sales Invoices where at least one POD field is empty.
 
@@ -82,6 +82,19 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 			from_date = year_start_date
 			to_date = year_end_date
 
+	# Fetch internal customers to exclude
+	internal_customers = [
+		c.name for c in frappe.get_all(
+			"Customer",
+			filters=[
+				["Customer", "is_internal_customer", "=", 1],
+				["Customer", "is_bns_internal_customer", "=", 1]
+			],
+			or_filters=True,
+			fields=["name"]
+		)
+	]
+
 	# Build base filters — always submitted, always for selected company, and always exclude Unregistered GST category
 	filters = [
 		["Sales Invoice", "docstatus", "=", 1],
@@ -90,6 +103,9 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 	if company:
 		filters.append(["Sales Invoice", "company", "=", company])
 	
+	if internal_customers:
+		filters.append(["Sales Invoice", "customer", "not in", internal_customers])
+
 	if from_date:
 		filters.append(["Sales Invoice", "posting_date", ">=", from_date])
 	if to_date:
@@ -97,8 +113,7 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 
 	if customer:
 		filters.append(["Sales Invoice", "customer", "=", customer])
-	if gst_category:
-		filters.append(["Sales Invoice", "gst_category", "=", gst_category])
+
 	if pod_status:
 		if pod_status == "Missing":
 			filters.append(["Sales Invoice", "bns_pod_status", "in", ["", None]])
@@ -115,10 +130,11 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 			"posting_date",
 			"grand_total",
 			"currency",
-			"gst_category",
 			"bns_pod_status",
 			"bns_pod_date",
 			"bns_pod_attachment",
+			"po_no",
+			"po_date"
 		],
 		order_by="posting_date desc",
 		limit=500,

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
@@ -86,11 +86,10 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 	internal_customers = [
 		c.name for c in frappe.get_all(
 			"Customer",
-			filters=[
+			or_filters=[
 				["Customer", "is_internal_customer", "=", 1],
 				["Customer", "is_bns_internal_customer", "=", 1]
 			],
-			or_filters=True,
 			fields=["name"]
 		)
 	]

--- a/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
+++ b/business_needed_solutions/business_needed_solutions/page/pod_dashboard/pod_dashboard.py
@@ -59,7 +59,23 @@ def _default_company():
 
 
 @frappe.whitelist()
-def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_date=None, customer=None, pod_status=None):
+def get_pending_pod_invoices(
+	company=None,
+	fiscal_year=None,
+	from_date=None,
+	to_date=None,
+	customer=None,
+	pod_status=None,
+	start=0,
+	page_length=20,
+	search_name=None,
+	search_customer=None,
+	search_posting_date=None,
+	search_grand_total=None,
+	search_pod_status=None,
+	search_pod_date=None,
+	search_pod_attachment=None,
+):
 	"""
 	Return submitted Sales Invoices where at least one POD field is empty.
 
@@ -67,12 +83,12 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 	  - bns_pod_status
 	  - bns_pod_date
 	  - bns_pod_attachment
-
-	Returns a list of dicts, ordered by posting_date descending.
 	"""
 	_require_dashboard_read()
 
 	company = company or _default_company()
+	start = frappe.utils.cint(start)
+	page_length = frappe.utils.cint(page_length) or 20
 	
 	if fiscal_year and not (from_date and to_date):
 		year_start_date, year_end_date = frappe.db.get_value(
@@ -119,9 +135,34 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 		else:
 			filters.append(["Sales Invoice", "bns_pod_status", "=", pod_status])
 
+	# Add quick column searches
+	if search_name:
+		filters.append(["Sales Invoice", "name", "like", f"%{search_name}%"])
+	if search_customer:
+		filters.append(["Sales Invoice", "customer_name", "like", f"%{search_customer}%"])
+	if search_posting_date:
+		filters.append(["Sales Invoice", "posting_date", "like", f"%{search_posting_date}%"])
+	if search_grand_total:
+		filters.append(["Sales Invoice", "grand_total", "like", f"%{search_grand_total}%"])
+	if search_pod_status:
+		filters.append(["Sales Invoice", "bns_pod_status", "like", f"%{search_pod_status}%"])
+	if search_pod_date:
+		filters.append(["Sales Invoice", "bns_pod_date", "like", f"%{search_pod_date}%"])
+	if search_pod_attachment:
+		filters.append(["Sales Invoice", "bns_pod_attachment", "like", f"%{search_pod_attachment}%"])
+
+	# Base pending OR filters — at least one of the 3 fields must be missing
+	or_filters = [
+		["Sales Invoice", "bns_pod_status", "in", ["", None]],
+		["Sales Invoice", "bns_pod_date", "is", "not set"],
+		["Sales Invoice", "bns_pod_attachment", "in", ["", None]]
+	]
+
+	# Query matching records for current page
 	invoices = frappe.get_all(
 		"Sales Invoice",
 		filters=filters,
+		or_filters=or_filters,
 		fields=[
 			"name",
 			"customer",
@@ -136,17 +177,42 @@ def get_pending_pod_invoices(company=None, fiscal_year=None, from_date=None, to_
 			"po_date"
 		],
 		order_by="posting_date desc",
-		limit=500,
+		start=start,
+		page_length=page_length
 	)
 
-	pending = [
-		inv for inv in invoices
-		if not (inv.get("bns_pod_status") and inv.get("bns_pod_date") and inv.get("bns_pod_attachment"))
-	]
+	# Calculate counts dynamically at database level
+	total_pending = frappe.get_all(
+		"Sales Invoice",
+		filters=filters,
+		or_filters=or_filters,
+		fields=["count(name) as total"]
+	)[0].total
+
+	missing_status = frappe.get_all(
+		"Sales Invoice",
+		filters=filters + [["Sales Invoice", "bns_pod_status", "in", ["", None]]],
+		fields=["count(name) as total"]
+	)[0].total
+
+	missing_date = frappe.get_all(
+		"Sales Invoice",
+		filters=filters + [["Sales Invoice", "bns_pod_date", "is", "not set"]],
+		fields=["count(name) as total"]
+	)[0].total
+
+	missing_attach = frappe.get_all(
+		"Sales Invoice",
+		filters=filters + [["Sales Invoice", "bns_pod_attachment", "in", ["", None]]],
+		fields=["count(name) as total"]
+	)[0].total
 
 	return {
-		"invoices": pending,
-		"total": len(pending),
+		"invoices": invoices,
+		"total": total_pending,
+		"missing_status": missing_status,
+		"missing_date": missing_date,
+		"missing_attachment": missing_attach,
 	}
 
 

--- a/business_needed_solutions/fixtures/custom_field.json
+++ b/business_needed_solutions/fixtures/custom_field.json
@@ -3245,7 +3245,7 @@
   "fieldname": "bns_pod_status",
   "fieldtype": "Select",
   "label": "POD Status",
-  "options": "\nDelivered\nIn-Transit\nIssue",
+  "options": "\nDelivered\nPartially Delivered\nNot Delivered",
   "insert_after": "bns_pod_section",
   "allow_on_submit": 1,
   "depends_on": "eval:doc.docstatus==1",

--- a/business_needed_solutions/fixtures/custom_field.json
+++ b/business_needed_solutions/fixtures/custom_field.json
@@ -3257,10 +3257,19 @@
  {
   "doctype": "Custom Field",
   "dt": "Sales Invoice",
+  "fieldname": "bns_pod_col_break_1",
+  "fieldtype": "Column Break",
+  "insert_after": "bns_pod_status",
+  "module": "Business Needed Solutions",
+  "name": "Sales Invoice-bns_pod_col_break_1"
+ },
+ {
+  "doctype": "Custom Field",
+  "dt": "Sales Invoice",
   "fieldname": "bns_pod_date",
   "fieldtype": "Date",
   "label": "POD Date",
-  "insert_after": "bns_pod_status",
+  "insert_after": "bns_pod_col_break_1",
   "allow_on_submit": 1,
   "depends_on": "eval:doc.docstatus==1",
   "module": "Business Needed Solutions",
@@ -3269,10 +3278,19 @@
  {
   "doctype": "Custom Field",
   "dt": "Sales Invoice",
+  "fieldname": "bns_pod_col_break_2",
+  "fieldtype": "Column Break",
+  "insert_after": "bns_pod_date",
+  "module": "Business Needed Solutions",
+  "name": "Sales Invoice-bns_pod_col_break_2"
+ },
+ {
+  "doctype": "Custom Field",
+  "dt": "Sales Invoice",
   "fieldname": "bns_pod_attachment",
   "fieldtype": "Attach",
   "label": "POD Attachment",
-  "insert_after": "bns_pod_date",
+  "insert_after": "bns_pod_col_break_2",
   "allow_on_submit": 1,
   "depends_on": "eval:doc.docstatus==1",
   "module": "Business Needed Solutions",

--- a/business_needed_solutions/fixtures/custom_field.json
+++ b/business_needed_solutions/fixtures/custom_field.json
@@ -3233,7 +3233,7 @@
   "fieldname": "bns_pod_section",
   "fieldtype": "Section Break",
   "label": "POD Details",
-  "insert_after": "customer_address",
+  "insert_after": "ignore_pricing_rule",
   "collapsible": 1,
   "depends_on": "eval:doc.docstatus==1",
   "module": "Business Needed Solutions",

--- a/business_needed_solutions/hooks.py
+++ b/business_needed_solutions/hooks.py
@@ -26,7 +26,7 @@ app_license = "Commercial"
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/business_needed_solutions/css/business_needed_solutions.css"
-app_include_js = ["/assets/business_needed_solutions/js/sales_invoice_form.js?v=122",
+app_include_js = [
                   "/assets/business_needed_solutions/js/purchase_invoice_form.js?v=216",
                   "/assets/business_needed_solutions/js/purchase_receipt_form.js?v=51",
                   "/assets/business_needed_solutions/js/delivery_note.js?v=137",
@@ -63,7 +63,7 @@ doctype_js = {
               "Stock Entry" : "public/js/doctype_item_grid_controls.js",
               
               # Sales Documents
-              "Sales Invoice" : "public/js/doctype_item_grid_controls.js",
+              "Sales Invoice" : ["public/js/doctype_item_grid_controls.js", "public/js/sales_invoice_form.js"],
               "Sales Order" : ["public/js/doctype_item_grid_controls.js", "public/js/update_items_override.js"],
               "Delivery Note" : "public/js/doctype_item_grid_controls.js",
               

--- a/business_needed_solutions/public/js/sales_invoice_form.js
+++ b/business_needed_solutions/public/js/sales_invoice_form.js
@@ -60,6 +60,16 @@ frappe.ui.form.on('Sales Invoice', {
     },
 
     refresh: function(frm) {
+        // Show missing POD warning banner if document is submitted and has incomplete POD fields
+        if (frm.doc.docstatus === 1) {
+            if (!frm.doc.bns_pod_status || !frm.doc.bns_pod_date || !frm.doc.bns_pod_attachment) {
+                frm.dashboard.set_headline(
+                    __("<strong>Alert:</strong> Proof of Delivery (POD) details are incomplete. Please complete them in the <strong>POD Details</strong> section in the Details tab."),
+                    "orange"
+                );
+            }
+        }
+
         // Value-only Credit Note shortcut: shown on draft return SIs. Flips
         // update_stock off and zeroes every item qty so the SI matches the
         // zero-qty-return shape detected by the BNS Settings opt-in bypass


### PR DESCRIPTION
## Overview
This PR introduces critical performance optimizations, usability enhancements, and UI refinements to the Proof of Delivery (POD) Dashboard and Sales Invoice page to resolve performance bottlenecks on large datasets (50,000+ invoices) and streamline inline data entry.

## Changes

### 1. Database-Level Performance & Pagination
* **Query Limit & Page Size**: Replaced client-side array filtering with server-side pagination (`start`, `page_length=500` by default). The dashboard now dynamically queries and displays 500 records per page.
* **Server-Side Summary Cards**: Dynamic KPI metric counts are now calculated directly at the database level for the entire filtered scope to ensure 100% data integrity without overhead.
* **Internal Customer Filter**: Implemented automatic exclusion of invoices belonging to internal customers (where `is_internal_customer = 1` or `is_bns_internal_customer = 1`).

### 2. Enhanced Search & Filters (Server-Side)
* **Debounced Column Search**: Column header quick-search inputs have been refactored to perform server-side `LIKE` queries with a `450ms` input debounce.
* **Caret & Focus Preservation**: Added UI state preservation logic to maintain active input focus and caret selection index across debounced table re-renders.
* **Fiscal Year & Date Range Sync**: Added a `Fiscal Year` link filter alongside `From Date` and `To Date`. Changing the fiscal year dynamically fetches its date limits and populates the date range fields.
* **Dropdown Z-Index Overlap Fix**: Adjusted `.pod-filters-card` styles (`z-index: 20; overflow: visible !important`) to prevent Autocomplete Link dropdowns from clipping under the table container.

### 3. Table UI & Field Refinement
* **Increased Table Height**: Set table container height limit to `calc(100vh - 220px)` (with `min-height: 500px`) for optimized vertical readability.
* **Inline Checkbox (Status Change)**: Simplified the `POD Status` column by replacing the status dropdown select with a direct tick-mark checkbox (`Accepted`), saving `"Delivered"` on tick.
* **PO Reference Integration**: Widened the Sales Invoice column and added standard Customer Purchase Order details (`po_no` and `po_date`) as a subtitle.
* **Customer Name**: The Customer column now queries and renders the `customer_name` instead of the ID.
* **GST & Unregistered Exclusion**: Removed GST Category column/filter and permanently excluded unregistered customers from the list.

### 4. Document Visibility & Security
* Added `depends_on: "eval:doc.docstatus==1"` to the POD Details section and custom fields in the Sales Invoice DocType. All POD fields are hidden in `Draft` state and visible/editable only after document `Submission`.
